### PR TITLE
Change the way it checks for special period

### DIFF
--- a/frontend/src/components/Modal/ImportClassesModal.css
+++ b/frontend/src/components/Modal/ImportClassesModal.css
@@ -8,6 +8,7 @@
 
 .import-input-container {
     display: flex;
+    align-items: center;
 }
 
 .import-title {
@@ -19,8 +20,7 @@
     padding: 10px;
     border-radius: 0.25rem;
     border: 1px solid #c4c4c4;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 10px 0;
     width: 100%;
     display: block;
     -webkit-box-sizing: border-box;
@@ -40,7 +40,8 @@
     font-weight: 600;
     display: block;
 }
-
-.import-tutorial {
-    width: 100%;
+.import-tutorial   {
+    width: 50%;
+    height: 200px;
+    margin-left: 10px;
 }


### PR DESCRIPTION
If someone decides to add a new special period in the future, that period will also get checked as well 

Example: break period in the middle of the day before activity period

<img width="491" alt="Screen Shot 2020-08-09 at 5 24 46 PM" src="https://user-images.githubusercontent.com/29236526/89742134-3c832080-da65-11ea-95ce-aa4ec8aa0990.png">

1, 2, break, 3, lunch, 4, 5, 6, (activity period even though it wasn't included in this schedule proposal)